### PR TITLE
Fix a custom kdf_iter that was not handled correctly when decrypting.

### DIFF
--- a/rncryptor_c.c
+++ b/rncryptor_c.c
@@ -1015,6 +1015,7 @@ unsigned char *rncryptorc_decrypt_data_with_password(const unsigned char *indata
         goto ExitProcessing;
     }
     ci->options = 0x01;
+    ci->kdf_iter = kdf_iter;
 
     rc = verify_rncryptor_format(ci->version,ci->options);
     if (rc != SUCCESS)
@@ -1146,6 +1147,8 @@ unsigned char *rncryptorc_decrypt_data_with_key(const unsigned char *indata,
         goto ExitProcessing;
     }
     log_debug("Decoded successfully");
+    
+    ci->kdf_iter = kdf_iter;
 
     /*
     ** copy the keys to our data structure, this way we don't have


### PR DESCRIPTION
This will cause HMAC validation to fail and can not communicate with other implementations such as PHP, Objc, Java, etc.

The attachment is an Xcode project with some tests for interacting with Objc.

BTW, this modification passed your unit test.

<details>
 <summary>Test Code</summary>

```objc
#import <Foundation/Foundation.h>
#import <RNCryptor-objc/RNEncryptor.h>
#import <RNCryptor-objc/RNDecryptor.h>
#import "rncryptor_c.h"

static NSString * const kkPassword = @"Password$#@";
static NSString * const kMessageString = @"Hello, world";

RNCryptorSettings getSettings() {
  RNCryptorSettings settings = kRNCryptorAES256Settings;
  settings.keySettings.rounds = 15;
  settings.HMACKeySettings.rounds = 15;
  return settings;
}

NSData *getEncryptedData() {
  NSError *error;
  NSData *messageData = [kMessageString dataUsingEncoding:NSUTF8StringEncoding];
  NSData *encryptedData = [RNEncryptor encryptData:messageData
                                      withSettings:getSettings()
                                          password:kkPassword
                                             error:&error];
  assert(encryptedData);
  assert(!error);
  return encryptedData;
}

NSData *getDecryptedData(NSData *encryptedData) {
  NSError *error;
  NSData *decryptedData = [RNDecryptor decryptData:encryptedData
                                      withSettings:getSettings()
                                          password:kkPassword
                                             error:&error];
  assert(decryptedData);
  assert(!error);
  return decryptedData;
}

unsigned char *encrypt_data(const unsigned char *indata,
                            int indata_len,
                            int *outdata_len) {
  char errbuf[1024] = {0};
  unsigned char *result = rncryptorc_encrypt_data_with_password(indata,
                                                                indata_len,
                                                                getSettings().keySettings.rounds,
                                                                kkPassword.UTF8String,
                                                                (int)kkPassword.length,
                                                                outdata_len,
                                                                errbuf,
                                                                1024);
  assert(*outdata_len > 0);
  assert(errbuf[0] == 0);
  return result;
}

unsigned char *decrypt_data(const unsigned char *indata,
                            int indata_len,
                            int *outdata_len) {
  char errbuf[1024] = {0};
  unsigned char *result = rncryptorc_decrypt_data_with_password(indata,
                                                                indata_len,
                                                                getSettings().keySettings.rounds,
                                                                kkPassword.UTF8String,
                                                                (int)kkPassword.length,
                                                                outdata_len,
                                                                errbuf,
                                                                1024);
  assert(*outdata_len > 0);
  assert(errbuf[0] == 0);
  return result;
}

void run(dispatch_block_t block, NSString *funcname) {
  printf("\n");
  NSLog(@"Begin %s %@", __FUNCTION__, funcname);
  !block ?: block();
  NSLog(@"End %s %@", __FUNCTION__, funcname);
}

void objc2objc() {
  NSData *encryptedData = getEncryptedData();
  NSData *decryptedData = getDecryptedData(encryptedData);
  NSString *str = [[NSString alloc] initWithData:decryptedData encoding:NSUTF8StringEncoding];
  assert([str isEqualToString:kMessageString]);
}

void objc2c() {
  NSData *encryptedData = getEncryptedData();
  int outdata_len = 0;
  unsigned char *result = decrypt_data(encryptedData.bytes, (int)encryptedData.length, &outdata_len);
  NSString *str = [[NSString alloc] initWithBytesNoCopy:result
                                                 length:outdata_len
                                               encoding:NSUTF8StringEncoding
                                           freeWhenDone:YES];
  assert([str isEqualToString:kMessageString]);
}

void c2c() {
  int outdata_len = 0;
  const unsigned char *data = (const unsigned char *)kMessageString.UTF8String;
  unsigned char *encrypt_result = encrypt_data(data,
                                              (int)kMessageString.length,
                                              &outdata_len);
  unsigned char *decrypt_result = decrypt_data(encrypt_result, outdata_len, &outdata_len);
  assert(0 == memcmp(data, decrypt_result, kMessageString.length));
  free(encrypt_result);
  free(decrypt_result);
}

void c2objc() {
  int outdata_len = 0;
  unsigned char *encrypt_result = encrypt_data((const unsigned char *)kMessageString.UTF8String,
                                               (int)kMessageString.length,
                                               &outdata_len);
  NSData *encryptedData = [[NSData alloc] initWithBytesNoCopy:encrypt_result length:outdata_len freeWhenDone:YES];
  NSData *decryptedData = getDecryptedData(encryptedData);
  NSString *str = [[NSString alloc] initWithData:decryptedData encoding:NSUTF8StringEncoding];
  assert([str isEqualToString:kMessageString]);
}


int main(int argc, const char * argv[]) {
  @autoreleasepool {
    rncryptorc_set_debug(1);
    run(^{ objc2objc(); }, @"objc2objc");
    run(^{ objc2c(); }, @"objc2c");
    run(^{ c2c(); }, @"c2c");
    run(^{ c2objc(); }, @"c2objc");
  }
  return 0;
}
```
</details>   


[RNCryptor-C-Objc.zip](https://github.com/RNCryptor/RNCryptor-C/files/2870199/RNCryptor-C-Objc.zip)
