### PR TITLE
Backward compatible with version 2 decryption.

### DIFF
--- a/ChangeLog.asc
+++ b/ChangeLog.asc
@@ -1,5 +1,10 @@
 = ChangeLog file for RNCryptor-C
 
+= v1.06
+* Backward compatible with version 2 decryption.
+  Thanks to Vincent <vincentxueios at gmail.com>
+(Feb-16-2019)
+
 = v1.05
 * Fix a custom kdf_iter that was not handled correctly when decrypting.
   Thanks to Vincent <vincentxueios at gmail.com>

--- a/rncryptor_c.c
+++ b/rncryptor_c.c
@@ -328,7 +328,7 @@ static RNCryptorInfo *decode_encrypted_blob(MutilsBlob *blob)
     /* version */
     ci->version = mutils_read_blob_byte(blob);
     /* update code when version changes */
-    if (ci->version != RNCRYPTOR_DATA_FORMAT_VERSION)
+    if (ci->version != RNCRYPTOR_DATA_FORMAT_VERSION && ci->version != RNCRYPTOR_DATA_FORMAT_VERSION_2)
     {
         log_err("Error: Unsupported RNCryptor data format version %02x",ci->version);
         goto ExitProcessing;
@@ -1305,7 +1305,7 @@ ExitProcessing:
 /* return SUCCESS or FAILURE */
 int verify_rncryptor_format(unsigned char version,unsigned char options)
 {
-    if (version == 0x03 && (options == 0x00 || options == 0x01))
+    if ((version == 0x03 || version == 0x02) && (options == 0x00 || options == 0x01))
     {
         return SUCCESS;
     }

--- a/rncryptor_c.h
+++ b/rncryptor_c.h
@@ -28,9 +28,10 @@
 #define MCFL             __FILE__,__LINE__
 #define MJL              __LINE__
 
-#define RNCRYPTORC_VERSION_S          "1.05"
-#define RNCRYPTOR_DATA_FORMAT_VERSION 0x03
-#define RNCRYPTOR3_KDF_ITER           10000
+#define RNCRYPTORC_VERSION_S            "1.06"
+#define RNCRYPTOR_DATA_FORMAT_VERSION   0x03
+#define RNCRYPTOR_DATA_FORMAT_VERSION_2 0x02
+#define RNCRYPTOR3_KDF_ITER             10000
 
 #define RNCRYPTOR_URL  "https://github.com/RNCryptor/RNCryptor"
 #define RNCRYPTORC_URL "https://github.com/RNCryptor/RNCryptor-C"


### PR DESCRIPTION
Based on [Changes since version 2](https://github.com/RNCryptor/RNCryptor-Spec/blob/master/RNCryptor-Spec-v3.md#changes-since-version-2), the version 3 implementation can actually be used to decrypt version 2 encrypted content. Only the caller is responsible for passing in the correct password and password length.

I made these changes based on my personal needs. My server returned version 2 encrypted data, so I need to be able to decrypt it. The differences between version 2 and version 3 can be handled automatically in other language implementations such as objc. C language version only need to let the caller handle this problem.

I am not sure if this PR needs to be merged. I am submitting this PR for those who have the same needs as me.
